### PR TITLE
Add support for setting the PM_SCORE field

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ Edit trello_sprint/auth.conf with your Trello api_key, api_secret and token. The
 
 Usage
 =====
+
+For generating a report:
+
 ```
-cd trello_sprint
-python3 main.py --config auth.conf "DFG-Networking-vNES Squad"
+python3 trello_sprint/main.py --config auth.conf "DFG-Networking-vNES Squad" report
 ```
+
+For setting the PM_SCORE field for the cards in the Backlog:
+
+```
+python3 trello_sprint/main.py --config auth.conf "DFG-Networking-vNES Squad" pm-score
+```
+
 
 Assumptions
 ===========

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 py-trello
+python-bugzilla


### PR DESCRIPTION
This patch is adding support for setting the PM_SCORE field for the
cards in the Backlog. For cards with the BUGZILLA field set, we will
fetch the PM_SCORE from that URL and add it to the Trello card, this
will help us prioritizing work during the planning.

This patch includes two new subcommands:

* report: Which does what this tool was suppose to do before, generate a
report about the Sprint

* pm-score: (see commit message)

Signed-off-by: Lucas Alvares Gomes <lucasagomes@gmail.com>